### PR TITLE
Memory optimization for Time.after

### DIFF
--- a/lib_incr/time.mli
+++ b/lib_incr/time.mli
@@ -9,11 +9,15 @@ type t
 (** Create a new ordering with a single element. O(1) *)
 val root : unit -> t
 
-(** [after t] inserts a new element to the ordering, greater than [t] but
+(** [after ~depth t] inserts a new element to the ordering, greater than [t] but
     less than all existing elements greater than [t].
 
+    The [depth] is used by [splice_out] to determine if the created element is
+    a child of [t]. The children of [t] are all the elements directly following
+    [t] and having a larger [depth] than it.
+
     O(1) amortized. *)
-val after  : ?on_forget:(unit -> unit) -> t -> t
+val after  : ?on_forget:(unit -> unit) -> depth:int -> t -> t
 
 (** Check if two elements belong to the same order. O(1) *)
 val same_order : t -> t -> bool
@@ -34,9 +38,9 @@ val forget : t -> unit
     You can check if it is the case with [is_valid]. *)
 val is_valid : t -> bool
 
-(** [splice_out ts te] forgets all times between [ts] and [te], so that
-    afterwards [te] immediately follows [ts]. *)
-val splice_out : t -> t -> unit
+(** [splice_out t] forgets all times immediately following and having a larger
+    depth than [t]. *)
+val splice_out : t -> unit
 
 val set_forget : t -> (unit -> unit) -> unit
 (** [set_forget t fn] sets [t]'s forget function to [fn].
@@ -51,6 +55,9 @@ val next : t -> t
 
 val prev : t -> t
 (** [prev t] is the time immediately before [t] (which must not be the first time). *)
+
+val depth : t -> int
+(** [depth t] is the depth of [t]. *)
 
 (* Algorithm due to:
    Two Simplified Algorithms for Maintaining Order in a List


### PR DESCRIPTION
This is a small departure from the original paper, but it's motivated by saving >300mo of memory in opam-repo-ci (on a particularly heavy workload). While there are some domain specific tricks that can be done in opam-repo-ci, I feel like optimizing `current_incr` can benefit to all ocurrent pipelines (here by reducing the GC pressure / memory load). The proposed changes should only reduce the memory usage and not change the semantics[^1], but it's updating some rather tricky code so I may have overlooked something!

The overall idea is that the `read` operation performs two `Time.after`, but we should be able to get the same results with only one. The timeline is populated with ordered elements that creates "parentheses" around each `read` with a time `start` and a time `stop`:

```
(  ( )  (  ( )  ( ) ) )  -- each (...) represent a `read` edge in the timeline
```

The timeline doesn't actually remember the start/stop nature of its elements, but the edges do. This leaves some room for interleaved parens like `( [ ) ]` but in practice this doesn't happen as a `Time.splice_out` of either would break the other. With this assumption, the timeline should always be perfectly balanced, so really it's representing a tree of nested `read` edges. An alternative representation for this tree can store only the `start` parens, along with its depth in the edge tree:

```
(  ( )  (  ( ) ( ) ) )  -- same as before
(0 (1   (1 (2  (2       -- each `(depth` represents an edge with an implicit stop
```

We can recover the `stop` location by walking to the right while the depth is larger than the one of `start`. The main point of keeping a `stop` element was to correctly splice out and forget the "children" elements of an edge in the tree: With the proposed refactoring, this is the same as forgetting all the elements following the start while they have a larger depth.

When new elements are inserted in the timeline during a propagate, they are added at the same location as before, with the right nesting depth (so they automatically land as a child of their `read` parent edge).

Hopefully this makes sense?... I feel pretty confident that the optimization is correct, but I'm also aware that incremental engines are really hard to get right! Did I miss something or introduce other issues? (The changes make the "order list" implementation less generic so it might be harder to understand in the future)

[1]: Actually the `Separate` map is ordering the elements differently... but that's not something users should depend on! That being said, I can restore the same order of execution as before by adding a bit more code if required.