### PR TITLE
Fix memory leak in readers Queue

### DIFF
--- a/lib_incr/queue.ml
+++ b/lib_incr/queue.ml
@@ -1,0 +1,45 @@
+(* A queue implemented as a circular double-linked list:
+   - The root of type ['a t] is represented by a node holding no value.
+   - The [prev]/[next] pointers forms a loop, with the root acting as a sentinel. *)
+
+type 'a value =
+  | Root
+  | Value of 'a
+
+type 'a elt = {
+  value: 'a value;
+  mutable prev: 'a elt;
+  mutable next: 'a elt;
+}
+
+type 'a t = 'a elt (* Such that its value = Root *)
+
+let is_root q = q.value = Root
+
+let create () =
+  let rec root = { value = Root; prev = root; next = root } in
+  root
+
+let add x q =
+  assert (is_root q);
+  let elt = { value = Value x; prev = q.prev; next = q } in
+  q.prev.next <- elt;
+  q.prev <- elt;
+  elt
+
+let remove elt =
+  assert (not (is_root elt));
+  let prev, next = elt.prev, elt.next in
+  prev.next <- next;
+  next.prev <- prev
+
+let iter f q =
+  assert (is_root q);
+  let rec iter f elt =
+    match elt.value with
+    | Root -> ()
+    | Value x ->
+      f x;
+      iter f elt.next
+  in
+  iter f q.next

--- a/lib_incr/queue.mli
+++ b/lib_incr/queue.mli
@@ -1,0 +1,17 @@
+(** A queue holding values of type ['a]. *)
+type 'a t
+
+(** Create a new empty queue. *)
+val create : unit -> 'a t
+
+(** Iterate on all the elements of the queue. *)
+val iter : ('a -> unit) -> 'a t -> unit
+
+(** An element of type ['a] present in the queue. *)
+type 'a elt
+
+(** Add a new value at the end of the queue, return its corresponding element. *)
+val add : 'a -> 'a t -> 'a elt
+
+(** Remove a previously added element from the queue. *)
+val remove : 'a elt -> unit

--- a/test/test.ml
+++ b/test/test.ml
@@ -159,12 +159,8 @@ let test_leak_readers () =
   change x false;
   propagate ();
   let h2 = heap () in
-  Alcotest.(check int) "Only reclaimed the array" (size + 1) (h1 - h2);
-  Alcotest.(check bool) "Memory leak" true (h2 > h0);
-  change y 1;     (* Bug: requires a write to clear the readers *)
-  let h3 = heap () in
-  Alcotest.(check int) "Memory usage constant" 0 @@ h3 - h0;
-  change x true;  (* Stop [x] from being GC'd before here *)
+  Alcotest.(check int) "No memory leak" 0 @@ h2 - h0;
+  change x false; (* Stop [x] from being GC'd before here *)
   propagate ()
 
 module String_map = Map.Make(String)


### PR DESCRIPTION
I think the code turned out rather nice, cleaning up a few edge cases with respect to invalid times in `Modifiable`.

It reuses the `Time.on_forget` callback to do a little dance depending on whether an `edge` is:
- Waiting for an update in some `readers` queue => its `on_forget` is setup to remove itself asap from that queue (this was missing)
- Scheduled in the priority queue => as before, its `on_forget` knows how to remove itself from the priority queue
Note the two added `Time.clear_forget` as we switch from one state to the other (and the previous `on_forget` becomes obsolete.)

I've also tested this PR with the new incoming crowbar tests :)