### PR TITLE
Expose ?eq for map

### DIFF
--- a/lib_incr/current_incr.ml
+++ b/lib_incr/current_incr.ml
@@ -17,7 +17,7 @@ let read x f d = Modifiable.read x (fun y -> f y d)
 
 let of_cc = Modifiable.create
 
-let map f x = of_cc (read x (fun x -> write (f x)))
+let map ?eq f x = of_cc (read x (fun x -> write ?eq (f x)))
 
 let change ?(eq=(==)) = Modifiable.change ~eq
 let propagate = Modifiable.propagate

--- a/lib_incr/current_incr.mli
+++ b/lib_incr/current_incr.mli
@@ -51,7 +51,7 @@ val on_release : (unit -> unit) -> unit
     Note that the order in which multiple such functions are called is somewhat
     unpredictable. *)
 
-val map : ('a -> 'b) -> 'a t -> 'b t
+val map : ?eq:('b -> 'b -> bool) -> ('a -> 'b) -> 'a t -> 'b t
 (** A convenience function to read a value, apply a function to it, and write the result. *)
 
 module Separate (Map : Map.S) : sig


### PR DESCRIPTION
The added custom `eq` test could be useful -- otherwise this isn't important at all, just a potential small clean up for [ocurrent `incr_map`](https://github.com/ocurrent/ocurrent/blob/bf325ff53b2d834824e7e2af590fc74ebcb7f553/lib_term/current_term.ml#L83-L88)